### PR TITLE
Add .gitattributes to make line endings more cross platform for OS X and Windows.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# https://help.github.com/articles/dealing-with-line-endings/
+# Set the default behavior, in case people don't have core.autocrlf set.
+* text=auto


### PR DESCRIPTION
On OS X this should help users use native lf instead of Windows crlf.
On OS X in vim, Windows line endings appear as ^M.
Reference
https://help.github.com/articles/dealing-with-line-endings