### PR TITLE
Fix swift implementation of write to use RX characteristic

### DIFF
--- a/BLEFramework/BLE/BLE.swift
+++ b/BLEFramework/BLE/BLE.swift
@@ -106,7 +106,7 @@ class BLE: NSObject, CBCentralManagerDelegate, CBPeripheralDelegate {
     
     func write(data data: NSData) {
         
-        guard let char = self.characteristics[RBL_CHAR_TX_UUID] else { return }
+        guard let char = self.characteristics[RBL_CHAR_RX_UUID] else { return }
         
         self.activePeripheral?.writeValue(data, forCharacteristic: char, type: .WithoutResponse)
     }


### PR DESCRIPTION
The swift implementation of the `write` method is incorrectly using the `TX` characteristic, it should be using the `RX` characteristic as per the ObjC implementation.

