### PR TITLE
Added optional method bleDidChangeState to BLEDelegate protocol 

### DIFF
--- a/BLEFramework/BLE/BLE.h
+++ b/BLEFramework/BLE/BLE.h
@@ -24,6 +24,7 @@
 -(void) bleDidDisconnect;
 -(void) bleDidUpdateRSSI:(NSNumber *) rssi;
 -(void) bleDidReceiveData:(unsigned char *) data length:(int) length;
+-(void) bleDidChangeState: (CBManagerState *) state;
 @required
 @end
 

--- a/BLEFramework/BLE/BLE.m
+++ b/BLEFramework/BLE/BLE.m
@@ -415,6 +415,7 @@ static int rssi = 0;
 {
 #if TARGET_OS_IPHONE
     NSLog(@"Status of CoreBluetooth central manager changed %d (%s)", central.state, [self centralManagerStateToString:central.state]);
+	[self.delegate bleDidChangeState: central.state];
 #else
     [self isLECapableHardware];
 #endif


### PR DESCRIPTION
Pass CBManagerState to your custom wrapper without creating new CBManager instance.